### PR TITLE
Added feature to support automatic inactivity trigger

### DIFF
--- a/Sources/Inactivity/InactivityTriggerType.swift
+++ b/Sources/Inactivity/InactivityTriggerType.swift
@@ -1,0 +1,25 @@
+//
+//  InactivityTriggerType.swift
+//  
+//
+//  Created by Randy Speakman on 7/15/22.
+//
+
+import Foundation
+
+
+/**
+ Enum that represents the type of inactivity trigger
+ 
+ Inactivity can be triggered by specific manual events like button clicks. It can also be handled automatically by any user interaction with the system like a random tap on the screen
+ */
+public enum InactivityTriggerType: String {
+    // Triggered by button actions etc
+    case manual
+    //Triggered by any interaction
+    case automatic
+}
+
+extension InactivityTriggerType: Identifiable {
+    public var id: String { rawValue }
+}

--- a/Sources/Inactivity/InactivityWatcher.swift
+++ b/Sources/Inactivity/InactivityWatcher.swift
@@ -51,8 +51,17 @@ public class InactivityWatcher: ObservableObject {
     }
 
     public func sendEvent() {
-        if self.stateChanged == .active, let lastTimeout = self.lastTimeout {
-            startWatch(timeout: lastTimeout)
+        
+        switch stateChanged {
+            // Handle case where user is already active when new activity is received by sendEvent
+            case .active:
+                if let lastTimeout = self.lastTimeout {
+                    startWatch(timeout: lastTimeout)
+                }
+            // Handle case where the user was inactive and new activity has been received by sendEvent. This means the user
+            //  is now active and we must change the state from inactive to active
+            case .inactive:
+                self.stateChanged = .active
         }
     }
 }


### PR DESCRIPTION
This pull request introduces the concept of an inactivity trigger type: manual and automatic. Manual is defined as a specific interaction such as tapping on a button. In response to the button tap you must call `startWatch()`. This is what happens in your sample app, **InactivityExample**, when the user taps on **Start**. Automatic is defined as any activity at all from the user and `startWatch()` is called automatically.

I have developed this for a slightly different use case than your original. In my use case I need to return to the login screen if the app has been inactive for a specific period of time. Any user interaction would be considered active for me.

I believe these changes will work for both of our uses cases. I have tested my changes with **InactivityExample** and it looks like it still works correctly.